### PR TITLE
SyntaxError: duplicate argument 'road_func' in function definition

### DIFF
--- a/halfcar/car.py
+++ b/halfcar/car.py
@@ -11,7 +11,7 @@ PI = math.pi
 
 
 class Car:
-    def __init__(self, road_func=None, properties=None, road_func=None):
+    def __init__(self, road_func=None, properties=None):
         """
         TODO
 


### PR DESCRIPTION
Fix syntax error

>     def __init__(self, road_func=None, properties=None, road_func=None):
>    ^
> SyntaxError: duplicate argument 'road_func' in function definition